### PR TITLE
univariate_wrapper.R: command not

### DIFF
--- a/univariate_config.xml
+++ b/univariate_config.xml
@@ -1,8 +1,8 @@
 <tool id="Univariate" name="Univariate" version="2.1.1">
   <description>Univariate statistics</description>
 
-  <command interpreter="Rscript">
-	univariate_wrapper.R
+  <command>
+    Rscript $__tool_directory__/univariate_wrapper.R
       dataMatrix_in "$dataMatrix_in"
       sampleMetadata_in "$sampleMetadata_in"
       variableMetadata_in "$variableMetadata_in"


### PR DESCRIPTION
C'est un peu étrange.
Dans les logs, il y a ça :
`galaxy.jobs.command_factory INFO 2016-06-24 12:19:43,841 Built script [/tmp/tmpKyJGax/job_working_directory/000/4/tool_script.sh] for tool command[[ "$CONDA_DEFAULT_ENV" = "/tmp/tmpKyJGax/job_working_directory/000/4/conda-env" ] || . /Users/pierrick/miniconda2/bin/activate '/tmp/tmpKyJGax/job_working_directory/000/4/conda-env' 2>&1 ; univariate_wrapper.R dataMatrix_in "/tmp/tmpKyJGax/files/000/dataset_1.dat" sampleMetadata_in "/tmp/tmpKyJGax/files/000/dataset_2.dat" variableMetadata_in "/tmp/tmpKyJGax/files/000/dataset_3.dat"  facC "ageGroup" tesC "kruskal" adjC "fdr" thrN "0.05"  variableMetadata_out "/tmp/tmpKyJGax/files/000/dataset_4.dat" information "/tmp/tmpKyJGax/files/000/dataset_5.dat"]`
On voit qu'il ne place par RScript avant le script.

Tentez avec cette nouvelle syntaxe ...
