### PR TITLE
fixed conda package names and versions

### DIFF
--- a/univariate_config.xml
+++ b/univariate_config.xml
@@ -2,8 +2,9 @@
   <description>Univariate statistics</description>
   
   <requirements>
-    <requirement type="package">r-batch</requirement>
-    <requirement type="package">r-PMCMR</requirement>
+    <requirement type="package" version="3.4.1">r-base</requirement>
+    <requirement type="package" version="1.1">r-batch</requirement>
+    <requirement type="package" version="4.1">r-pmcmr</requirement>
   </requirements>
 
   <stdio>


### PR DESCRIPTION
typo in r-rmcmr

fixed versions. r-base > 3.2 is important because https://github.com/workflow4metabolomics/lcmsmatching/pull/41 

