### PR TITLE
Pin the dependences' versions

### DIFF
--- a/univariate_config.xml
+++ b/univariate_config.xml
@@ -2,8 +2,8 @@
   <description>Univariate statistics</description>
   
   <requirements>
-    <requirement type="package">r-batch</requirement>
-    <requirement type="package">r-PMCMR</requirement>
+    <requirement type="package" version="1.1_4">r-batch</requirement>
+    <requirement type="package" version="4.1">r-PMCMR</requirement>
   </requirements>
 
   <stdio>


### PR DESCRIPTION
Otherwise, Conda will always take the laster one.